### PR TITLE
adding links to URLs for the github api + new update field

### DIFF
--- a/watchtower/_io.py
+++ b/watchtower/_io.py
@@ -7,7 +7,7 @@ def _update_and_save(filename, raw, old_raw=None):
     """
     if old_raw is not None:
         raw = pd.concat([raw, old_raw], ignore_index=True)
-        raw = raw.drop_duplicates(subset=['id'])
+        raw = raw.drop_duplicates(subset=['html_url'])
     try:
         os.makedirs(os.path.dirname(filename))
     except OSError:

--- a/watchtower/comments_.py
+++ b/watchtower/comments_.py
@@ -13,6 +13,9 @@ def update_comments(user, project, auth=None, state="all", since=None,
     """
     Updates the comments information for a user / project.
 
+    See https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository
+    for more information.
+
     Parameters
     ----------
     user : string

--- a/watchtower/commits_.py
+++ b/watchtower/commits_.py
@@ -53,6 +53,9 @@ def update_commits(user, project=None, auth=None, since=None,
                    verbose=False, **params):
     """Update the commit data for a repository.
 
+    See https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
+    for more information.
+
     Parameters
     ----------
     user : string

--- a/watchtower/issues_.py
+++ b/watchtower/issues_.py
@@ -14,6 +14,9 @@ def update_issues(user, project, auth=None, state="all", since=None,
     """
     Updates the issues information for a user / project.
 
+    See https://developer.github.com/v3/issues/#list-issues-for-a-repository
+    for more information.
+
     Parameters
     ----------
     user : string

--- a/watchtower/reviews_.py
+++ b/watchtower/reviews_.py
@@ -13,6 +13,9 @@ def update_reviews(user, project, pull_request_ids, auth=None, since=None,
     """
     Updates the reviews information for a user / project.
 
+    See https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
+    for more information.
+
     Parameters
     ----------
     user : string


### PR DESCRIPTION
This PR does two things:

1. adds a link to the relevant page in the GitHub API for each `update_` function.
2. Uses `html_url` instead of `id` to update the DataFrames when using the `update_` functions. This is because not all of the data types have an `id` field, whereas I think they do all have an `html_url` field.
